### PR TITLE
feat: Accept cron format as a function that returns a cron.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+no_load*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.analysis.typeCheckingMode": "basic"
+}

--- a/src/croning/schedule.py
+++ b/src/croning/schedule.py
@@ -2,7 +2,9 @@ from typing import Callable, Any
 from .scheduler import Scheduler
 
 
-def schedule_function(cron_format: str, identificator: str | None = None):
+def schedule_function(
+    cron_format: str | Callable[[], str], identificator: str | None = None
+):
 
     def register(function: Callable[[], Any]):
 


### PR DESCRIPTION
Now you can pass a function that returns a cron format instead of a final cron format